### PR TITLE
Fix Angular component styleUrls

### DIFF
--- a/src/app/admin-template/admin-template.component.ts
+++ b/src/app/admin-template/admin-template.component.ts
@@ -6,7 +6,7 @@ import { MatToolbar } from '@angular/material/toolbar';
 @Component({
   selector: 'app-admin-template',
   templateUrl: './admin-template.component.html',
-  styleUrl: './admin-template.component.css'
+  styleUrls: ['./admin-template.component.css']
 })
 export class AdminTemplateComponent {
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrl: './app.component.css'
+  styleUrls: ['./app.component.css']
 })
 export class AppComponent {
   title = 'sistema-tickets-frontend';

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
-  styleUrl: './dashboard.component.css'
+  styleUrls: ['./dashboard.component.css']
 })
 export class DashboardComponent {
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrl: './home.component.css'
+  styleUrls: ['./home.component.css']
 })
 export class HomeComponent {
 

--- a/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-load-tecnicos',
   templateUrl: './load-tecnicos.component.html',
-  styleUrl: './load-tecnicos.component.css'
+  styleUrls: ['./load-tecnicos.component.css']
 })
 export class LoadTecnicosComponent {
 

--- a/src/app/load-tickets/load-tickets.component.ts
+++ b/src/app/load-tickets/load-tickets.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-load-tickets',
   templateUrl: './load-tickets.component.html',
-  styleUrl: './load-tickets.component.css'
+  styleUrls: ['./load-tickets.component.css']
 })
 export class LoadTicketsComponent {
 

--- a/src/app/new-ticket/new-ticket.component.ts
+++ b/src/app/new-ticket/new-ticket.component.ts
@@ -9,7 +9,7 @@ import Swal from 'sweetalert2';
 @Component({
   selector: 'app-new-ticket',
   templateUrl: './new-ticket.component.html',
-  styleUrl: './new-ticket.component.css'
+  styleUrls: ['./new-ticket.component.css']
 })
 export class NewTicketComponent implements OnInit{
   ticketFormGroup!: FormGroup;

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',
-  styleUrl: './profile.component.css'
+  styleUrls: ['./profile.component.css']
 })
 export class ProfileComponent {
 

--- a/src/app/tecnico-detalles/tecnico-detalles.component.ts
+++ b/src/app/tecnico-detalles/tecnico-detalles.component.ts
@@ -8,7 +8,7 @@ import { Tecnico } from '../models/tecnicos.model'; // Adjust the import path as
 @Component({
   selector: 'app-tecnico-detalles',
   templateUrl: './tecnico-detalles.component.html',
-  styleUrl: './tecnico-detalles.component.css'
+  styleUrls: ['./tecnico-detalles.component.css']
 })
 export class TecnicoDetallesComponent {
   tecnico!: Tecnico;

--- a/src/app/tecnicos/tecnicos.component.ts
+++ b/src/app/tecnicos/tecnicos.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-tecnicos',
   templateUrl: './tecnicos.component.html',
-  styleUrl: './tecnicos.component.css'
+  styleUrls: ['./tecnicos.component.css']
 })
 export class TecnicosComponent implements OnInit {
 

--- a/src/app/tickets/tickets.component.ts
+++ b/src/app/tickets/tickets.component.ts
@@ -8,7 +8,7 @@ import { TecnicosService } from '../services/tecnicos.service';
 @Component({
   selector: 'app-tickets',
   templateUrl: './tickets.component.html',
-  styleUrl: './tickets.component.css'
+  styleUrls: ['./tickets.component.css']
 })
 export class TicketsComponent implements OnInit {
 public tickets: any;


### PR DESCRIPTION
## Summary
- use `styleUrls` array syntax for Angular components so component styles load correctly

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6860a55bf46483239bdaee47dbca02e4