### PR TITLE
Implement JWT utilities for login

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/config/SecurityConfig.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/config/SecurityConfig.java
@@ -12,15 +12,22 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import com.compulandia.sistematickets.config.JwtRequestFilter;
+import com.compulandia.sistematickets.config.AuthEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-    
-    private final UserDetailsService userDetailsService;
 
-    public SecurityConfig(UserDetailsService userDetailsService) {
+    private final UserDetailsService userDetailsService;
+    private final JwtRequestFilter jwtRequestFilter;
+    private final AuthEntryPoint authEntryPoint;
+
+    public SecurityConfig(UserDetailsService userDetailsService, JwtRequestFilter jwtRequestFilter, AuthEntryPoint authEntryPoint) {
         this.userDetailsService = userDetailsService;
+        this.jwtRequestFilter = jwtRequestFilter;
+        this.authEntryPoint = authEntryPoint;
     }
 
     @Bean
@@ -28,11 +35,13 @@ public class SecurityConfig {
         return http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/register", "/authenticate", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint))
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/JwtTokenUtil.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/JwtTokenUtil.java
@@ -3,6 +3,12 @@ package com.compulandia.sistematickets.services;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import java.util.Base64;
 
 @Component
 public class JwtTokenUtil {
@@ -11,20 +17,42 @@ public class JwtTokenUtil {
     private String jwtSecret;
 
     @Value("${jwt.expirationMs}")
-    private int jwtExpirationMs; {
+    private int jwtExpirationMs;
 
-  }
+    private byte[] getSigningKey() {
+        return Base64.getDecoder().decode(jwtSecret);
+    }
 
-  public String generateToken(UserDetails u) {
-    return null;
-  }         // usa jjwt builder
+    // usa jjwt builder
+    public String generateToken(UserDetails userDetails) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtExpirationMs);
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(Keys.hmacShaKeyFor(getSigningKey()), SignatureAlgorithm.HS256)
+                .compact();
+    }
 
-  public String getUsernameFromToken(String t) {
-    return null;
-  }
+    public String getUsernameFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(getSigningKey()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
 
-  public boolean validateToken(String t, UserDetails u) {
-    return false;
-  }
+    public boolean validateToken(String token, UserDetails userDetails) {
+        String username = getUsernameFromToken(token);
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(getSigningKey()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        Date expiration = claims.getExpiration();
+        return (username.equals(userDetails.getUsername()) && expiration.after(new Date()));
+    }
 }
 


### PR DESCRIPTION
## Summary
- implement JWT helper for login tokens
- update security configuration to include JWT filter and entrypoint

## Testing
- `mvn -f sistema-tickets-backend/pom.xml test` *(fails: network unreachable and malformed POM)*
- `npm test` *(fails: Chrome binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a7f9c88c8323999ef72371d1bb3c